### PR TITLE
Propagate cluster_name to cassandra.yaml

### DIFF
--- a/pkg/config/builder.go
+++ b/pkg/config/builder.go
@@ -471,6 +471,7 @@ func k8ssandraOverrides(merged map[string]interface{}, configInput *ConfigInput,
 	delete(merged, "broadcast_address") // Sets it to the same as listen_address
 	merged["broadcast_rpc_address"] = nodeInfo.BroadcastIP
 	merged["endpoint_snitch"] = "GossipingPropertyFileSnitch"
+	merged["cluster_name"] = configInput.ClusterInfo.Name
 
 	return merged
 }

--- a/pkg/config/builder_test.go
+++ b/pkg/config/builder_test.go
@@ -210,6 +210,9 @@ func TestCassandraYamlWriting(t *testing.T) {
 	}
 
 	// Verify our k8ssandra overrides are set
+	clusterName := configInput.ClusterInfo.Name
+	require.Equal(clusterName, cassandraYaml["cluster_name"])
+
 	seedProviders := cassandraYaml["seed_provider"].([]interface{})
 	seedProvider := seedProviders[0].(map[string]interface{})
 	require.Equal("org.apache.cassandra.locator.K8SeedProvider", seedProvider["class_name"])


### PR DESCRIPTION
This MR propagate cluster_name parameter in cassandra.yaml according to ClusterInfo

Fix for https://github.com/k8ssandra/k8ssandra-client/issues/17