### PR TITLE
Fix ordering of arguments in NewManagementClient

### DIFF
--- a/pkg/mgmtapi/client.go
+++ b/pkg/mgmtapi/client.go
@@ -12,7 +12,7 @@ import (
 // NewManagementClient returns a new instance for management-api go-client
 func NewManagementClient(ctx context.Context, client client.Client, namespace, datacenter string) (httphelper.NodeMgmtClient, error) {
 	manager := cassdcutil.NewManager(client)
-	dc, err := manager.CassandraDatacenter(ctx, namespace, datacenter)
+	dc, err := manager.CassandraDatacenter(ctx, datacenter, namespace)
 	if err != nil {
 		return httphelper.NodeMgmtClient{}, err
 	}


### PR DESCRIPTION
The last PR we merged had an error (caused by additional arguments being required due to upgrades to cass-operator) where the name of a datacenter and it's namespace was reversed in one function call. 

Somehow, this functionality is not exercised in the tests for this repo, and the bug has only turned up when integrating it as a library elsewhere.