### PR TITLE
Add the ability to run short tests only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ vet: ## Run go vet against code.
 test: fmt vet lint envtest ## Run tests
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(GO_FLAGS) ./... -coverprofile cover.out
 
-.PHONE: test-short
+.PHONY: test-short
 test-short: fmt vet lint envtest ## Run tests
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -short $(GO_FLAGS) ./... -coverprofile cover.out
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ SHELL = /usr/bin/env bash -o pipefail
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.28.x
 
+GO_FLAGS ?= -v
+
 .PHONY: all
 all: build
 
@@ -46,7 +48,11 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: fmt vet lint envtest ## Run tests
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -v ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(GO_FLAGS) ./... -coverprofile cover.out
+
+.PHONE: test-short
+test-short: fmt vet lint envtest ## Run tests
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -short $(GO_FLAGS) ./... -coverprofile cover.out
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint against code

--- a/cmd/kubectl-k8ssandra/register/registration.go
+++ b/cmd/kubectl-k8ssandra/register/registration.go
@@ -52,10 +52,7 @@ func getDefaultServiceAccount(saName, saNamespace string) *corev1.ServiceAccount
 }
 
 func (e *RegistrationExecutor) RegisterCluster() error {
-	log.Printf("Registering cluster from %s Context: %s to %s Context: %s",
-		registration.GetKubeconfigFileLocation(e.SourceKubeconfig), e.SourceContext,
-		registration.GetKubeconfigFileLocation(e.DestKubeconfig), e.DestContext,
-	)
+	log.Printf("Registering cluster from context: %s to context: %s", e.SourceContext, e.DestContext)
 
 	if e.SourceContext == e.DestContext && e.SourceKubeconfig == e.DestKubeconfig {
 		return NonRecoverable("source and destination context and kubeconfig are the same, you should not register the same cluster to itself. Reference it by leaving the k8sContext field blank instead")

--- a/cmd/kubectl-k8ssandra/register/suite_test.go
+++ b/cmd/kubectl-k8ssandra/register/suite_test.go
@@ -2,7 +2,6 @@ package register
 
 import (
 	"os"
-	"testing"
 
 	"github.com/k8ssandra/k8ssandra-client/internal/envtest"
 )
@@ -13,12 +12,12 @@ var (
 	err      error
 )
 
-func TestMain(m *testing.M) {
+func startKind() (deferFunc func()) {
 	testDir, err = os.MkdirTemp("", "k8ssandra-client-test")
 	if err != nil {
 		panic(err.Error())
 	}
-	os.Exit(envtest.RunMultiKind(m, func(e *envtest.MultiK8sEnvironment) {
+	return envtest.RunMultiKind(func(e *envtest.MultiK8sEnvironment) {
 		multiEnv = e
-	}, []int{1, 1}, testDir))
+	}, []int{1, 1}, testDir)
 }

--- a/internal/envtest/envtest.go
+++ b/internal/envtest/envtest.go
@@ -125,13 +125,7 @@ func (e *Environment) Start() {
 		panic(err)
 	}
 
-	//+kubebuilder:scaffold:scheme
-
 	e.client = k8sClient
-	// e.Kubeconfig, err = CreateKubeconfigFileForRestConfig(e.env.Config)
-	// if err != nil {
-	// 	panic(err)
-	// }
 }
 
 func (e *Environment) Stop() {

--- a/pkg/helmutil/crds_test.go
+++ b/pkg/helmutil/crds_test.go
@@ -16,6 +16,10 @@ import (
 )
 
 func TestUpgradingCRDs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	require := require.New(t)
 	chartNames := []string{"cass-operator"}
 	for _, chartName := range chartNames {


### PR DESCRIPTION
Running ``make test-short`` or ``make GO_FLAGS="-v -short" test`` will skip the long running tests such as dual-kind setups and e2e CRD upgrade.