### PR TITLE
Remove old CRD stored versions when upgrading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 0.3.0
+VERSION ?= 0.7.0
 
 COMMIT := $(shell git rev-parse --short HEAD)
 DATE := $(shell date +%Y%m%d)
@@ -14,7 +14,7 @@ SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.28.x
+ENVTEST_K8S_VERSION = 1.31.x
 
 GO_FLAGS ?= -v
 
@@ -83,7 +83,7 @@ $(LOCALBIN):
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 
-GOLINT_VERSION ?= 1.56.2
+GOLINT_VERSION ?= 1.61.0
 
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.

--- a/pkg/helmutil/crds.go
+++ b/pkg/helmutil/crds.go
@@ -51,13 +51,13 @@ func NewUpgrader(c client.Client, repoName, repoURL, chartName string, subCharts
 func (u *Upgrader) Upgrade(ctx context.Context, chartVersion string) ([]unstructured.Unstructured, error) {
 	log.SetLevel(log.DebugLevel)
 	log.Info("Processing request to upgrade project CustomResourceDefinitions", "repoName", u.repoName, "chartName", u.chartName, "chartVersion", chartVersion)
-	chartDir, err := GetChartTargetDir(u.repoName, u.chartName, chartVersion)
+	chartDir, err := GetChartTargetDir(u.repoName, u.chartName)
 	if err != nil {
 		return nil, err
 	}
 
 	if fs, err := os.Stat(chartDir); os.IsNotExist(err) {
-		log.Info("Downloading chart release from remote repository", "repoURL", u.repoURL, "chartName", u.chartName, "chartVersion", chartVersion)
+		log.Info("Downloading chart release from remote repository", "repoURL", u.repoURL, "chartName", u.chartName, "chartVersion", chartVersion, "chartDir", chartDir)
 		downloadDir, err := DownloadChartRelease(u.repoName, u.repoURL, u.chartName, chartVersion)
 		if err != nil {
 			return nil, err

--- a/pkg/helmutil/crds_test.go
+++ b/pkg/helmutil/crds_test.go
@@ -2,12 +2,17 @@ package helmutil_test
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/k8ssandra/k8ssandra-client/pkg/helmutil"
+	"github.com/k8ssandra/k8ssandra-client/pkg/util"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -25,7 +30,7 @@ func TestUpgradingCRDs(t *testing.T) {
 	for _, chartName := range chartNames {
 		namespace := env.CreateNamespace(t)
 		kubeClient := env.GetClientInNamespace(namespace)
-		require.NoError(cleanCache("k8ssandra", chartName))
+		require.NoError(cleanCache("k8ssandra", chartName, "0.42.0"))
 
 		// creating new upgrader
 		u, err := helmutil.NewUpgrader(kubeClient, helmutil.K8ssandraRepoName, helmutil.StableK8ssandraRepoURL, chartName, []string{})
@@ -59,7 +64,7 @@ func TestUpgradingCRDs(t *testing.T) {
 		require.False(strings.HasPrefix(descRunsAsCassandra, "DEPRECATED"))
 
 		// Upgrading to 0.46.1
-		require.NoError(cleanCache("k8ssandra", chartName))
+		require.NoError(cleanCache("k8ssandra", chartName, "0.46.1"))
 		_, err = u.Upgrade(context.TODO(), "0.46.1")
 		require.NoError(err)
 
@@ -77,11 +82,160 @@ func TestUpgradingCRDs(t *testing.T) {
 	}
 }
 
-func cleanCache(repoName, chartName string) error {
-	chartDir, err := helmutil.GetChartTargetDir(repoName, chartName)
+func cleanCache(repoName, chartName, version string) error {
+	chartDir, err := helmutil.GetChartTargetDir(repoName, chartName, version)
 	if err != nil {
 		return err
 	}
 
 	return os.RemoveAll(chartDir)
+}
+
+func TestUpgradingStoredVersions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	require := require.New(t)
+	chartName := "test-chart"
+	namespace := env.CreateNamespace(t)
+	kubeClient := env.GetClientInNamespace(namespace)
+	require.NoError(cleanCache("k8ssandra", chartName, "0.1.0"))
+	require.NoError(cleanCache("k8ssandra", chartName, "0.2.0"))
+	require.NoError(cleanCache("k8ssandra", chartName, "0.3.0"))
+
+	// Copy testfiles
+	chartDir, err := helmutil.GetChartTargetDir(helmutil.K8ssandraRepoName, chartName, "0.1.0")
+	require.NoError(err)
+
+	crdDir := filepath.Join(chartDir, "crds")
+	_, err = util.CreateIfNotExistsDir(crdDir)
+	require.NoError(err)
+	crdSrc := filepath.Join("..", "..", "testfiles", "crd-upgrader", "multiversion-clientconfig-mockup-v1alpha1.yaml")
+	require.NoError(copyFile(crdSrc, filepath.Join(crdDir, "clientconfig.yaml")))
+
+	chartDir, err = helmutil.GetChartTargetDir(helmutil.K8ssandraRepoName, chartName, "0.2.0")
+	require.NoError(err)
+
+	crdDir = filepath.Join(chartDir, "crds")
+	_, err = util.CreateIfNotExistsDir(crdDir)
+	require.NoError(err)
+	crdSrc = filepath.Join("..", "..", "testfiles", "crd-upgrader", "multiversion-clientconfig-mockup-both.yaml")
+	require.NoError(copyFile(crdSrc, filepath.Join(crdDir, "clientconfig.yaml")))
+
+	chartDir, err = helmutil.GetChartTargetDir(helmutil.K8ssandraRepoName, chartName, "0.3.0")
+	require.NoError(err)
+
+	crdDir = filepath.Join(chartDir, "crds")
+	_, err = util.CreateIfNotExistsDir(crdDir)
+	require.NoError(err)
+	crdSrc = filepath.Join("..", "..", "testfiles", "crd-upgrader", "multiversion-clientconfig-mockup-v1beta1.yaml")
+	require.NoError(copyFile(crdSrc, filepath.Join(crdDir, "clientconfig.yaml")))
+
+	testOptions := envtest.CRDInstallOptions{
+		PollInterval: 100 * time.Millisecond,
+		MaxTime:      10 * time.Second,
+	}
+
+	// creating new upgrader
+	u, err := helmutil.NewUpgrader(kubeClient, helmutil.K8ssandraRepoName, helmutil.StableK8ssandraRepoURL, chartName, []string{})
+	require.NoError(err)
+
+	crds, err := u.Upgrade(context.TODO(), "0.1.0")
+	require.NoError(err)
+
+	targetCrd := &apiextensions.CustomResourceDefinition{}
+	objs := []*apiextensions.CustomResourceDefinition{}
+	for _, crd := range crds {
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(crd.UnstructuredContent(), targetCrd)
+		require.NoError(err)
+		objs = append(objs, targetCrd)
+	}
+
+	require.NotEmpty(objs)
+	require.NotEmpty(targetCrd.GetName())
+	require.NoError(envtest.WaitForCRDs(env.RestConfig(), objs, testOptions))
+	require.NoError(kubeClient.Get(context.TODO(), client.ObjectKey{Name: targetCrd.GetName()}, targetCrd))
+
+	require.Equal([]string{"v1alpha1"}, targetCrd.Status.StoredVersions)
+
+	// Upgrade to 0.2.0
+
+	crds, err = u.Upgrade(context.TODO(), "0.2.0")
+	require.NoError(err)
+	for _, crd := range crds {
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(crd.UnstructuredContent(), targetCrd)
+		require.NoError(err)
+		objs = append(objs, targetCrd)
+	}
+	require.NotEmpty(objs)
+	require.NoError(envtest.WaitForCRDs(env.RestConfig(), objs, testOptions))
+	require.NoError(kubeClient.Get(context.TODO(), client.ObjectKey{Name: targetCrd.GetName()}, targetCrd))
+	require.Equal([]string{"v1alpha1", "v1beta1"}, targetCrd.Status.StoredVersions)
+
+	// Upgrade to 0.3.0
+
+	crds, err = u.Upgrade(context.TODO(), "0.3.0")
+	require.NoError(err)
+	for _, crd := range crds {
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(crd.UnstructuredContent(), targetCrd)
+		require.NoError(err)
+		objs = append(objs, targetCrd)
+	}
+	require.NotEmpty(objs)
+	require.NoError(envtest.WaitForCRDs(env.RestConfig(), objs, testOptions))
+	require.NoError(kubeClient.Get(context.TODO(), client.ObjectKey{Name: targetCrd.GetName()}, targetCrd))
+	require.Equal([]string{"v1beta1"}, targetCrd.Status.StoredVersions)
+
+	// Sanity check, install 0.2.0 and only update to 0.3.0 (there should be no storedVersion of v1alpha1)
+	require.NoError(kubeClient.Delete(context.TODO(), targetCrd))
+	require.Eventually(func() bool {
+		err = kubeClient.Get(context.TODO(), client.ObjectKey{Name: targetCrd.GetName()}, targetCrd)
+		return err != nil && client.IgnoreNotFound(err) == nil
+	}, time.Second*5, time.Millisecond*100)
+
+	// Install 0.2.0
+
+	crds, err = u.Upgrade(context.TODO(), "0.2.0")
+	require.NoError(err)
+	for _, crd := range crds {
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(crd.UnstructuredContent(), targetCrd)
+		require.NoError(err)
+		objs = append(objs, targetCrd)
+	}
+	require.NotEmpty(objs)
+	require.NoError(envtest.WaitForCRDs(env.RestConfig(), objs, testOptions))
+	require.NoError(kubeClient.Get(context.TODO(), client.ObjectKey{Name: targetCrd.GetName()}, targetCrd))
+	require.Equal([]string{"v1beta1"}, targetCrd.Status.StoredVersions)
+
+	// Upgrade to 0.3.0
+
+	crds, err = u.Upgrade(context.TODO(), "0.3.0")
+	require.NoError(err)
+	for _, crd := range crds {
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(crd.UnstructuredContent(), targetCrd)
+		require.NoError(err)
+		objs = append(objs, targetCrd)
+	}
+	require.NotEmpty(objs)
+	require.NoError(envtest.WaitForCRDs(env.RestConfig(), objs, testOptions))
+	require.NoError(kubeClient.Get(context.TODO(), client.ObjectKey{Name: targetCrd.GetName()}, targetCrd))
+	require.Equal([]string{"v1beta1"}, targetCrd.Status.StoredVersions)
+}
+
+func copyFile(source, target string) error {
+	src, err := os.Open(source)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("failed to open %s", source))
+	}
+	defer src.Close()
+
+	dst, err := os.Create(target)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("failed to open %s", target))
+	}
+	defer dst.Close()
+
+	_, err = io.Copy(dst, src)
+	return err
 }

--- a/pkg/helmutil/crds_test.go
+++ b/pkg/helmutil/crds_test.go
@@ -30,7 +30,7 @@ func TestUpgradingCRDs(t *testing.T) {
 	for _, chartName := range chartNames {
 		namespace := env.CreateNamespace(t)
 		kubeClient := env.GetClientInNamespace(namespace)
-		require.NoError(cleanCache("k8ssandra", chartName, "0.42.0"))
+		require.NoError(cleanCache("k8ssandra", chartName))
 
 		// creating new upgrader
 		u, err := helmutil.NewUpgrader(kubeClient, helmutil.K8ssandraRepoName, helmutil.StableK8ssandraRepoURL, chartName, []string{})
@@ -64,7 +64,7 @@ func TestUpgradingCRDs(t *testing.T) {
 		require.False(strings.HasPrefix(descRunsAsCassandra, "DEPRECATED"))
 
 		// Upgrading to 0.46.1
-		require.NoError(cleanCache("k8ssandra", chartName, "0.46.1"))
+		require.NoError(cleanCache("k8ssandra", chartName))
 		_, err = u.Upgrade(context.TODO(), "0.46.1")
 		require.NoError(err)
 
@@ -82,8 +82,8 @@ func TestUpgradingCRDs(t *testing.T) {
 	}
 }
 
-func cleanCache(repoName, chartName, version string) error {
-	chartDir, err := helmutil.GetChartTargetDir(repoName, chartName, version)
+func cleanCache(repoName, chartName string) error {
+	chartDir, err := helmutil.GetChartTargetDir(repoName, chartName)
 	if err != nil {
 		return err
 	}
@@ -100,36 +100,16 @@ func TestUpgradingStoredVersions(t *testing.T) {
 	chartName := "test-chart"
 	namespace := env.CreateNamespace(t)
 	kubeClient := env.GetClientInNamespace(namespace)
-	require.NoError(cleanCache("k8ssandra", chartName, "0.1.0"))
-	require.NoError(cleanCache("k8ssandra", chartName, "0.2.0"))
-	require.NoError(cleanCache("k8ssandra", chartName, "0.3.0"))
+	require.NoError(cleanCache("k8ssandra", chartName))
 
 	// Copy testfiles
-	chartDir, err := helmutil.GetChartTargetDir(helmutil.K8ssandraRepoName, chartName, "0.1.0")
+	chartDir, err := helmutil.GetChartTargetDir(helmutil.K8ssandraRepoName, chartName)
 	require.NoError(err)
 
 	crdDir := filepath.Join(chartDir, "crds")
 	_, err = util.CreateIfNotExistsDir(crdDir)
 	require.NoError(err)
 	crdSrc := filepath.Join("..", "..", "testfiles", "crd-upgrader", "multiversion-clientconfig-mockup-v1alpha1.yaml")
-	require.NoError(copyFile(crdSrc, filepath.Join(crdDir, "clientconfig.yaml")))
-
-	chartDir, err = helmutil.GetChartTargetDir(helmutil.K8ssandraRepoName, chartName, "0.2.0")
-	require.NoError(err)
-
-	crdDir = filepath.Join(chartDir, "crds")
-	_, err = util.CreateIfNotExistsDir(crdDir)
-	require.NoError(err)
-	crdSrc = filepath.Join("..", "..", "testfiles", "crd-upgrader", "multiversion-clientconfig-mockup-both.yaml")
-	require.NoError(copyFile(crdSrc, filepath.Join(crdDir, "clientconfig.yaml")))
-
-	chartDir, err = helmutil.GetChartTargetDir(helmutil.K8ssandraRepoName, chartName, "0.3.0")
-	require.NoError(err)
-
-	crdDir = filepath.Join(chartDir, "crds")
-	_, err = util.CreateIfNotExistsDir(crdDir)
-	require.NoError(err)
-	crdSrc = filepath.Join("..", "..", "testfiles", "crd-upgrader", "multiversion-clientconfig-mockup-v1beta1.yaml")
 	require.NoError(copyFile(crdSrc, filepath.Join(crdDir, "clientconfig.yaml")))
 
 	testOptions := envtest.CRDInstallOptions{
@@ -161,6 +141,12 @@ func TestUpgradingStoredVersions(t *testing.T) {
 
 	// Upgrade to 0.2.0
 
+	require.NoError(cleanCache("k8ssandra", chartName))
+	_, err = util.CreateIfNotExistsDir(crdDir)
+	require.NoError(err)
+	crdSrc = filepath.Join("..", "..", "testfiles", "crd-upgrader", "multiversion-clientconfig-mockup-both.yaml")
+	require.NoError(copyFile(crdSrc, filepath.Join(crdDir, "clientconfig.yaml")))
+
 	crds, err = u.Upgrade(context.TODO(), "0.2.0")
 	require.NoError(err)
 	for _, crd := range crds {
@@ -174,6 +160,12 @@ func TestUpgradingStoredVersions(t *testing.T) {
 	require.Equal([]string{"v1alpha1", "v1beta1"}, targetCrd.Status.StoredVersions)
 
 	// Upgrade to 0.3.0
+
+	require.NoError(cleanCache("k8ssandra", chartName))
+	_, err = util.CreateIfNotExistsDir(crdDir)
+	require.NoError(err)
+	crdSrc = filepath.Join("..", "..", "testfiles", "crd-upgrader", "multiversion-clientconfig-mockup-v1beta1.yaml")
+	require.NoError(copyFile(crdSrc, filepath.Join(crdDir, "clientconfig.yaml")))
 
 	crds, err = u.Upgrade(context.TODO(), "0.3.0")
 	require.NoError(err)
@@ -196,6 +188,12 @@ func TestUpgradingStoredVersions(t *testing.T) {
 
 	// Install 0.2.0
 
+	require.NoError(cleanCache("k8ssandra", chartName))
+	_, err = util.CreateIfNotExistsDir(crdDir)
+	require.NoError(err)
+	crdSrc = filepath.Join("..", "..", "testfiles", "crd-upgrader", "multiversion-clientconfig-mockup-both.yaml")
+	require.NoError(copyFile(crdSrc, filepath.Join(crdDir, "clientconfig.yaml")))
+
 	crds, err = u.Upgrade(context.TODO(), "0.2.0")
 	require.NoError(err)
 	for _, crd := range crds {
@@ -209,6 +207,12 @@ func TestUpgradingStoredVersions(t *testing.T) {
 	require.Equal([]string{"v1beta1"}, targetCrd.Status.StoredVersions)
 
 	// Upgrade to 0.3.0
+
+	require.NoError(cleanCache("k8ssandra", chartName))
+	_, err = util.CreateIfNotExistsDir(crdDir)
+	require.NoError(err)
+	crdSrc = filepath.Join("..", "..", "testfiles", "crd-upgrader", "multiversion-clientconfig-mockup-v1beta1.yaml")
+	require.NoError(copyFile(crdSrc, filepath.Join(crdDir, "clientconfig.yaml")))
 
 	crds, err = u.Upgrade(context.TODO(), "0.3.0")
 	require.NoError(err)

--- a/pkg/helmutil/fetch.go
+++ b/pkg/helmutil/fetch.go
@@ -110,13 +110,11 @@ func ExtractChartRelease(saved, repoName, chartName, chartVersion string) (strin
 	return extractDir, nil
 }
 
-func GetChartTargetDir(repoName, chartName, chartVersion string) (string, error) {
+func GetChartTargetDir(repoName, chartName string) (string, error) {
 	extractDir, err := util.GetCacheDir(repoName, chartName)
 	if err != nil {
 		return "", err
 	}
-
-	extractDir = filepath.Join(extractDir, chartVersion)
 
 	return extractDir, err
 }

--- a/pkg/helmutil/fetch.go
+++ b/pkg/helmutil/fetch.go
@@ -110,11 +110,13 @@ func ExtractChartRelease(saved, repoName, chartName, chartVersion string) (strin
 	return extractDir, nil
 }
 
-func GetChartTargetDir(repoName, chartName string) (string, error) {
+func GetChartTargetDir(repoName, chartName, chartVersion string) (string, error) {
 	extractDir, err := util.GetCacheDir(repoName, chartName)
 	if err != nil {
 		return "", err
 	}
+
+	extractDir = filepath.Join(extractDir, chartVersion)
 
 	return extractDir, err
 }

--- a/testfiles/crd-upgrader/multiversion-clientconfig-mockup-both.yaml
+++ b/testfiles/crd-upgrader/multiversion-clientconfig-mockup-both.yaml
@@ -1,0 +1,103 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: clientconfigmocks.config.k8ssandra.io
+spec:
+  group: config.k8ssandra.io
+  names:
+    kind: ClientConfigMock
+    listKind: ClientConfigMockList
+    plural: clientconfigmocks
+    singular: clientconfigmock
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClientConfig is the Schema for the kubeconfigs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClientConfigSpec defines the desired state of KubeConfig
+            properties:
+              kubeConfigSecret:
+                description: |-
+                  KubeConfigSecret should reference an existing secret; the actual configuration will be read from
+                  this secret's "kubeconfig" key.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+            type: object
+        type: object
+    served: true
+    storage: false
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ClientConfig is the Schema for the kubeconfigs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClientConfigSpec defines the desired state of KubeConfig
+            properties:
+              contextName:
+                description: ContextName allows to override the object name for context-name.
+                  If not set, the ClientConfig.Name is used as context name
+                type: string
+              kubeConfigSecret:
+                description: |-
+                  KubeConfigSecret should reference an existing secret; the actual configuration will be read from
+                  this secret's "kubeconfig" key.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/testfiles/crd-upgrader/multiversion-clientconfig-mockup-v1alpha1.yaml
+++ b/testfiles/crd-upgrader/multiversion-clientconfig-mockup-v1alpha1.yaml
@@ -1,0 +1,57 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: clientconfigmocks.config.k8ssandra.io
+spec:
+  group: config.k8ssandra.io
+  names:
+    kind: ClientConfigMock
+    listKind: ClientConfigMockList
+    plural: clientconfigmocks
+    singular: clientconfigmock
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClientConfig is the Schema for the kubeconfigs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClientConfigSpec defines the desired state of KubeConfig
+            properties:
+              kubeConfigSecret:
+                description: |-
+                  KubeConfigSecret should reference an existing secret; the actual configuration will be read from
+                  this secret's "kubeconfig" key.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/testfiles/crd-upgrader/multiversion-clientconfig-mockup-v1beta1.yaml
+++ b/testfiles/crd-upgrader/multiversion-clientconfig-mockup-v1beta1.yaml
@@ -1,0 +1,61 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: clientconfigmocks.config.k8ssandra.io
+spec:
+  group: config.k8ssandra.io
+  names:
+    kind: ClientConfigMock
+    listKind: ClientConfigMockList
+    plural: clientconfigmocks
+    singular: clientconfigmock
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ClientConfig is the Schema for the kubeconfigs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClientConfigSpec defines the desired state of KubeConfig
+            properties:
+              contextName:
+                description: ContextName allows to override the object name for context-name.
+                  If not set, the ClientConfig.Name is used as context name
+                type: string
+              kubeConfigSecret:
+                description: |-
+                  KubeConfigSecret should reference an existing secret; the actual configuration will be read from
+                  this secret's "kubeconfig" key.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+            type: object
+        type: object
+    served: true
+    storage: true


### PR DESCRIPTION
If upgrading CRD has different versions than the ones stored on the server, remove the previously stored versions as stored versions

Fixes #70 