### PR TITLE
Add kubectl to the docker image

### DIFF
--- a/cmd/kubectl-k8ssandra/Dockerfile
+++ b/cmd/kubectl-k8ssandra/Dockerfile
@@ -2,7 +2,6 @@
 FROM golang:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
-ARG YQ_VERSION
 
 WORKDIR /workspace
 
@@ -22,9 +21,27 @@ COPY build/ build/
 # Build
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o kubectl-k8ssandra cmd/kubectl-k8ssandra/main.go
 
+FROM redhat/ubi8-minimal:latest AS ubi-builder
+
+ARG YQ_VERSION
+ARG KUBE_VERSION
+
+# Install kubectl
+RUN cat <<EOF | tee /etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes
+baseurl=https://pkgs.k8s.io/core:/stable:/v${KUBE_VERSION:-1.32}/rpm/
+enabled=1
+gpgcheck=1
+gpgkey=https://pkgs.k8s.io/core:/stable:/v${KUBE_VERSION:-1.32}/rpm/repodata/repomd.xml.key
+EOF
+
+RUN microdnf install -y kubectl
+
+WORKDIR /workspace
+
 # Install yq
 RUN curl -L "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION:-4.45.1}/yq_${TARGETOS:-linux}_${TARGETARCH:-amd64}" -o yq
-
 
 # Build the UBI image
 FROM redhat/ubi8-minimal:latest
@@ -42,7 +59,8 @@ LABEL description="Part of the toolset for the DataStax Kubernetes Operator for 
 WORKDIR /
 COPY --from=builder /workspace/kubectl-k8ssandra .
 COPY --from=builder --chown=65532:65532 /workspace/build/ .cache/
-COPY --from=builder --chown=65532:65532 --chmod=755 /workspace/yq /usr/bin/yq
+COPY --from=ubi-builder --chown=65532:65532 --chmod=755 /workspace/yq /usr/bin/yq
+COPY --from=ubi-builder /usr/bin/kubectl /usr/bin/kubectl
 COPY ./LICENSE /licenses/
 
 USER 65532:65532


### PR DESCRIPTION
Fixes #78 

```
➜  k8ssandra-client git:(main) ✗ docker run -it --entrypoint kubectl k8ssandra/k8ssandra-client:v0.7.0-dev.dc8ac64-20250326
kubectl controls the Kubernetes cluster manager.

 Find more information at: https://kubernetes.io/docs/reference/kubectl/

Basic Commands (Beginner):
  create          Create a resource from a file or from stdin
  expose          Take a replication controller, service, deployment or pod and expose it as a new Kubernetes service
  run             Run a particular image on the cluster
  set             Set specific features on objects

Basic Commands (Intermediate):
  explain         Get documentation for a resource
  get             Display one or many resources
  edit            Edit a resource on the server
  delete          Delete resources by file names, stdin, resources and names, or by resources and label selector

Deploy Commands:
  rollout         Manage the rollout of a resource
  scale           Set a new size for a deployment, replica set, or replication controller
  autoscale       Auto-scale a deployment, replica set, stateful set, or replication controller

Cluster Management Commands:
  certificate     Modify certificate resources
  cluster-info    Display cluster information
  top             Display resource (CPU/memory) usage
  cordon          Mark node as unschedulable
  uncordon        Mark node as schedulable
  drain           Drain node in preparation for maintenance
  taint           Update the taints on one or more nodes

Troubleshooting and Debugging Commands:
  describe        Show details of a specific resource or group of resources
  logs            Print the logs for a container in a pod
  attach          Attach to a running container
  exec            Execute a command in a container
  port-forward    Forward one or more local ports to a pod
  proxy           Run a proxy to the Kubernetes API server
  cp              Copy files and directories to and from containers
  auth            Inspect authorization
  debug           Create debugging sessions for troubleshooting workloads and nodes
  events          List events

Advanced Commands:
  diff            Diff the live version against a would-be applied version
  apply           Apply a configuration to a resource by file name or stdin
  patch           Update fields of a resource
  replace         Replace a resource by file name or stdin
  wait            Experimental: Wait for a specific condition on one or many resources
  kustomize       Build a kustomization target from a directory or URL

Settings Commands:
  label           Update the labels on a resource
  annotate        Update the annotations on a resource
  completion      Output shell completion code for the specified shell (bash, zsh, fish, or powershell)

Subcommands provided by plugins:

Other Commands:
  api-resources   Print the supported API resources on the server
  api-versions    Print the supported API versions on the server, in the form of "group/version"
  config          Modify kubeconfig files
  plugin          Provides utilities for interacting with plugins
  version         Print the client and server version information

Usage:
  kubectl [flags] [options]

Use "kubectl <command> --help" for more information about a given command.
Use "kubectl options" for a list of global command-line options (applies to all commands).
➜  k8ssandra-client git:(main) ✗ docker run -it --entrypoint yq k8ssandra/k8ssandra-client:v0.7.0-dev.dc8ac64-20250326
Usage:
  yq [flags]
  yq [command]

Examples:

# yq tries to auto-detect the file format based off the extension, and defaults to YAML if it's unknown (or piping through STDIN)
# Use the '-p/--input-format' flag to specify a format type.
cat file.xml | yq -p xml

# read the "stuff" node from "myfile.yml"
yq '.stuff' < myfile.yml

# update myfile.yml in place
yq -i '.stuff = "foo"' myfile.yml

# print contents of sample.json as idiomatic YAML
yq -P -oy sample.json


Available Commands:
  completion  Generate the autocompletion script for the specified shell
  eval        (default) Apply the expression to each document in each yaml file in sequence
  eval-all    Loads _all_ yaml documents of _all_ yaml files and runs expression once
  help        Help about any command

Flags:
  -C, --colors                        force print with colors
      --csv-auto-parse                parse CSV YAML/JSON values (default true)
      --csv-separator char            CSV Separator character (default ,)
  -e, --exit-status                   set exit status if there are no matches or null or false is returned
      --expression string             forcibly set the expression argument. Useful when yq argument detection thinks your expression is a file.
      --from-file string              Load expression from specified file.
  -f, --front-matter string           (extract|process) first input as yaml front-matter. Extract will pull out the yaml content, process will run the expression against the yaml content, leaving the remaining data intact
      --header-preprocess             Slurp any header comments and separators before processing expression. (default true)
  -h, --help                          help for yq
  -I, --indent int                    sets indent level for output (default 2)
  -i, --inplace                       update the file in place of first file given.
  -p, --input-format string           [auto|a|yaml|y|json|j|props|p|csv|c|tsv|t|xml|x|base64|uri|toml|lua|l] parse format for input. (default "auto")
      --lua-globals                   output keys as top-level global variables
      --lua-prefix string             prefix (default "return ")
      --lua-suffix string             suffix (default ";\n")
      --lua-unquoted                  output unquoted string keys (e.g. {foo="bar"})
  -M, --no-colors                     force print with no colors
  -N, --no-doc                        Don't print document separators (---)
  -0, --nul-output                    Use NUL char to separate values. If unwrap scalar is also set, fail if unwrapped scalar contains NUL char.
  -n, --null-input                    Don't read input, simply evaluate the expression given. Useful for creating docs from scratch.
  -o, --output-format string          [auto|a|yaml|y|json|j|props|p|csv|c|tsv|t|xml|x|base64|uri|toml|shell|s|lua|l] output format type. (default "auto")
  -P, --prettyPrint                   pretty print, shorthand for '... style = ""'
      --properties-array-brackets     use [x] in array paths (e.g. for SpringBoot)
      --properties-separator string   separator to use between keys and values (default " = ")
  -s, --split-exp string              print each result (or doc) into a file named (exp). [exp] argument must return a string. You can use $index in the expression as the result counter. The necessary directories will be created.
      --split-exp-file string         Use a file to specify the split-exp expression.
      --string-interpolation          Toggles strings interpolation of \(exp) (default true)
      --tsv-auto-parse                parse TSV YAML/JSON values (default true)
  -r, --unwrapScalar                  unwrap scalar, print the value with no quotes, colors or comments. Defaults to true for yaml (default true)
  -v, --verbose                       verbose mode
  -V, --version                       Print version information and quit
      --xml-attribute-prefix string   prefix for xml attributes (default "+@")
      --xml-content-name string       name for xml content (if no attribute name is present). (default "+content")
      --xml-directive-name string     name for xml directives (e.g. <!DOCTYPE thing cat>) (default "+directive")
      --xml-keep-namespace            enables keeping namespace after parsing attributes (default true)
      --xml-proc-inst-prefix string   prefix for xml processing instructions (e.g. <?xml version="1"?>) (default "+p_")
      --xml-raw-token                 enables using RawToken method instead Token. Commonly disables namespace translations. See https://pkg.go.dev/encoding/xml#Decoder.RawToken for details. (default true)
      --xml-skip-directives           skip over directives (e.g. <!DOCTYPE thing cat>)
      --xml-skip-proc-inst            skip over process instructions (e.g. <?xml version="1"?>)
      --xml-strict-mode               enables strict parsing of XML. See https://pkg.go.dev/encoding/xml for more details.

Use "yq [command] --help" for more information about a command.

➜  k8ssandra-client git:(main) ✗
```