### PR TITLE
Upgrade yq and kubectl to fix CVEs

### DIFF
--- a/cmd/kubectl-k8ssandra/Dockerfile
+++ b/cmd/kubectl-k8ssandra/Dockerfile
@@ -30,10 +30,10 @@ ARG KUBE_VERSION
 RUN cat <<EOF | tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://pkgs.k8s.io/core:/stable:/v${KUBE_VERSION:-1.32}/rpm/
+baseurl=https://pkgs.k8s.io/core:/stable:/v${KUBE_VERSION:-1.33}/rpm/
 enabled=1
 gpgcheck=1
-gpgkey=https://pkgs.k8s.io/core:/stable:/v${KUBE_VERSION:-1.32}/rpm/repodata/repomd.xml.key
+gpgkey=https://pkgs.k8s.io/core:/stable:/v${KUBE_VERSION:-1.33}/rpm/repodata/repomd.xml.key
 EOF
 
 RUN microdnf install -y kubectl
@@ -41,7 +41,7 @@ RUN microdnf install -y kubectl
 WORKDIR /workspace
 
 # Install yq
-RUN curl -L "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION:-4.45.4}/yq_${TARGETOS:-linux}_${TARGETARCH:-amd64}" -o yq
+RUN curl -L "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION:-4.47.1}/yq_${TARGETOS:-linux}_${TARGETARCH:-amd64}" -o yq
 
 # Build the UBI image
 FROM redhat/ubi9-micro:latest


### PR DESCRIPTION
This pull request updates the `Dockerfile` for the `kubectl-k8ssandra` command to use newer versions of Kubernetes and `yq`. These changes ensure compatibility with the latest stable releases and improve the reliability of the build process.

Version updates:

* Updated the Kubernetes version in the repository URL from `1.32` to `1.33` in `cmd/kubectl-k8ssandra/Dockerfile`. This change includes adjustments to both the `baseurl` and `gpgkey` paths to match the new version.
* Updated the `yq` version from `4.45.4` to `4.47.1` in `cmd/kubectl-k8ssandra/Dockerfile`. This ensures the image uses the latest features and bug fixes provided by `yq`.