### PR TITLE
Add per pod overrides config

### DIFF
--- a/cmd/kubectl-k8ssandra/config/builder.go
+++ b/cmd/kubectl-k8ssandra/config/builder.go
@@ -20,8 +20,9 @@ type builderOptions struct {
 	configFlags *genericclioptions.ConfigFlags
 	genericclioptions.IOStreams
 
-	inputDir  string
-	outputDir string
+	inputDir    string
+	podSpecific string
+	outputDir   string
 }
 
 func newBuilderOptions(streams genericclioptions.IOStreams) *builderOptions {
@@ -56,6 +57,7 @@ func NewBuilderCmd(streams genericclioptions.IOStreams) *cobra.Command {
 
 	fl := cmd.Flags()
 	fl.StringVar(&o.inputDir, "input", "", "read config files from this directory instead of default")
+	fl.StringVar(&o.podSpecific, "override", "", "read overrides from this directory instead of default")
 	fl.StringVar(&o.outputDir, "output", "", "write config files to this directory instead of default")
 	o.configFlags.AddFlags(fl)
 	return cmd
@@ -78,6 +80,6 @@ func (c *builderOptions) Validate() error {
 func (c *builderOptions) Run() error {
 	ctx := context.Background()
 
-	builder := config.NewBuilder(c.inputDir, c.outputDir)
+	builder := config.NewBuilder(c.inputDir, c.outputDir, c.podSpecific)
 	return builder.Build(ctx)
 }

--- a/internal/envtest/envtest.go
+++ b/internal/envtest/envtest.go
@@ -136,7 +136,7 @@ func (e *Environment) Stop() {
 
 func (e *Environment) CreateNamespace(t *testing.T) string {
 	namespace := strings.ToLower(t.Name())
-	if err := kubernetes.CreateNamespaceIfNotExists(e.client, namespace); err != nil {
+	if err := kubernetes.CreateNamespaceIfNotExists(t.Context(), e.client, namespace); err != nil {
 		t.FailNow()
 	}
 

--- a/pkg/cassdcutil/secrets_test.go
+++ b/pkg/cassdcutil/secrets_test.go
@@ -1,7 +1,6 @@
 package cassdcutil
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -44,7 +43,7 @@ func TestCassandraAuthDetails(t *testing.T) {
 	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cassdc, secret).Build()
 	cassManager := &CassManager{client: client}
 
-	authDetails, err := cassManager.CassandraAuthDetails(context.TODO(), cassdc)
+	authDetails, err := cassManager.CassandraAuthDetails(t.Context(), cassdc)
 	assert.NoError(err)
 	assert.NotNil(authDetails)
 

--- a/pkg/config/builder.go
+++ b/pkg/config/builder.go
@@ -19,6 +19,7 @@ import (
 	"github.com/adutra/goalesce"
 	metadata "github.com/burmanm/definitions-parser/pkg/types"
 	gentypes "github.com/burmanm/definitions-parser/pkg/types/generated"
+	"github.com/charmbracelet/log"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
@@ -26,6 +27,9 @@ import (
 const (
 	// $CASSANDRA_CONF could modify this, but we override it in the mgmt-api
 	defaultInputDir = "/cassandra-base-config"
+
+	// default directory under configInputDir which could include per pod modifications to the configuration
+	defaultPodSpecificDir = "override"
 
 	// docker-entrypoint.sh will copy the files from here, so we need all the outputs to target this
 	defaultOutputDir = "/config"
@@ -39,12 +43,14 @@ const (
 type Builder struct {
 	configInputDir  string
 	configOutputDir string
+	podSpecificDir  string
 }
 
-func NewBuilder(overrideConfigInput, overrideConfigOutput string) *Builder {
+func NewBuilder(overrideConfigInput, overrideConfigOutput, overridePodSpecificDir string) *Builder {
 	b := &Builder{
 		configInputDir:  defaultInputDir,
 		configOutputDir: defaultOutputDir,
+		podSpecificDir:  defaultPodSpecificDir,
 	}
 
 	if overrideConfigInput != "" {
@@ -53,6 +59,10 @@ func NewBuilder(overrideConfigInput, overrideConfigOutput string) *Builder {
 
 	if overrideConfigOutput != "" {
 		b.configOutputDir = overrideConfigOutput
+	}
+
+	if overridePodSpecificDir != "" {
+		b.podSpecificDir = overridePodSpecificDir
 	}
 
 	return b
@@ -74,6 +84,28 @@ func (b *Builder) Build(ctx context.Context) error {
 		return err
 	}
 
+	log.Infof("Parsed ConfigInput and NodeInfo for node %s", nodeInfo.Name)
+
+	// Read optional per-pod overrides from inputDir/<POD_NAME>.yaml|json
+	podOverrides, err := readPodOverrides(b.configInputDir, b.podSpecificDir, nodeInfo)
+	if err != nil {
+		return err
+	}
+
+	// Apply non-cassandra.yaml overrides directly into configInput so they participate in standard merging
+	if podOverrides != nil {
+		// Merge cassandra-env options
+		if podOverrides.CassandraEnv.MallocArenaMax > 0 {
+			configInput.CassandraEnv.MallocArenaMax = podOverrides.CassandraEnv.MallocArenaMax
+		}
+		if podOverrides.CassandraEnv.HeapDumpDir != "" {
+			configInput.CassandraEnv.HeapDumpDir = podOverrides.CassandraEnv.HeapDumpDir
+		}
+		if len(podOverrides.CassandraEnv.AdditionalOpts) > 0 {
+			configInput.CassandraEnv.AdditionalOpts = append(configInput.CassandraEnv.AdditionalOpts, podOverrides.CassandraEnv.AdditionalOpts...)
+		}
+	}
+
 	// Create rack information
 	if err := createRackProperties(configInput, nodeInfo, b.configOutputDir); err != nil {
 		return err
@@ -84,13 +116,17 @@ func (b *Builder) Build(ctx context.Context) error {
 		return err
 	}
 
-	// Create jvm*-server.options
-	if err := createJVMOptions(configInput, b.configInputDir, b.configOutputDir); err != nil {
+	// Create jvm*-server.options (merge per-pod overrides inside the helper)
+	if err := createJVMOptions(configInput, b.configInputDir, b.configOutputDir, podOverrides); err != nil {
 		return err
 	}
 
-	// Create cassandra.yaml
-	if err := createCassandraYaml(configInput, nodeInfo, b.configInputDir, b.configOutputDir); err != nil {
+	// Create cassandra.yaml (apply per-pod overrides at the very end)
+	var finalCassYaml map[string]interface{}
+	if podOverrides != nil {
+		finalCassYaml = podOverrides.CassYaml
+	}
+	if err := createCassandraYaml(configInput, nodeInfo, b.configInputDir, b.configOutputDir, finalCassYaml); err != nil {
 		return err
 	}
 
@@ -106,9 +142,13 @@ func (b *Builder) Build(ctx context.Context) error {
 
 func parseConfigInput() (*ConfigInput, error) {
 	configInputStr := os.Getenv("CONFIG_FILE_DATA")
+	return parseConfigInputFromData(configInputStr)
+}
+
+func parseConfigInputFromData(data string) (*ConfigInput, error) {
 	configInput := &ConfigInput{}
 
-	d := json.NewDecoder(strings.NewReader(configInputStr))
+	d := json.NewDecoder(strings.NewReader(data))
 	d.UseNumber() // This decodes the numbers as strings
 	if err := d.Decode(configInput); err != nil {
 		return nil, err
@@ -119,8 +159,10 @@ func parseConfigInput() (*ConfigInput, error) {
 
 func parseNodeInfo() (*NodeInfo, error) {
 	rackName := os.Getenv("RACK_NAME")
+	podName := os.Getenv("POD_NAME")
 
 	n := &NodeInfo{
+		Name: podName,
 		Rack: rackName,
 	}
 
@@ -242,14 +284,20 @@ func createCassandraEnv(configInput *ConfigInput, sourceDir, targetDir string) e
 }
 
 // createJVMOptions writes all the jvm*-server.options
-func createJVMOptions(configInput *ConfigInput, sourceDir, targetDir string) error {
-	if err := createServerJVMOptions(configInput.ServerOptions, "jvm-server.options", sourceDir, targetDir); err != nil {
+func createJVMOptions(configInput *ConfigInput, sourceDir, targetDir string, podOverrides *ConfigInput) error {
+	if err := createServerJVMOptions(configInput.ServerOptions, podOverrides.ServerOptions, "jvm-server.options", sourceDir, targetDir); err != nil {
 		return err
 	}
-	if err := createServerJVMOptions(configInput.ServerOptions11, "jvm11-server.options", sourceDir, targetDir); err != nil {
+
+	if err := createServerJVMOptions(configInput.ServerOptions11, podOverrides.ServerOptions11, "jvm11-server.options", sourceDir, targetDir); err != nil {
 		return err
 	}
-	if err := createServerJVMOptions(configInput.ServerOptions17, "jvm17-server.options", sourceDir, targetDir); err != nil {
+
+	if err := createServerJVMOptions(configInput.ServerOptions17, podOverrides.ServerOptions17, "jvm17-server.options", sourceDir, targetDir); err != nil {
+		return err
+	}
+
+	if err := createServerJVMOptions(configInput.ServerOptions21, podOverrides.ServerOptions21, "jvm21-server.options", sourceDir, targetDir); err != nil {
 		return err
 	}
 
@@ -268,12 +316,41 @@ func optionsFilenameToMap(filename string) map[string]metadata.Metadata {
 	}
 }
 
-func createServerJVMOptions(options map[string]any, filename, sourceDir, targetDir string) error {
+func createServerJVMOptions(baseOptions, overrideOptions map[string]interface{}, filename, sourceDir, targetDir string) error {
 	// Read the current jvm-server-options as []string, do linear search to replace the values with the inputs we get
 	optionsPath := filepath.Join(sourceDir, filename)
 	currentOptions, err := readJvmServerOptions(optionsPath)
 	if err != nil {
 		return err
+	}
+
+	options := make(map[string]interface{})
+	for k, v := range baseOptions {
+		options[k] = v
+	}
+
+	// We could have this logic in the next section also, but I feel like it's easier to read if separated
+	if overrideAddOpts, found := overrideOptions["additional-jvm-opts"]; found {
+		if addOpts, found := options["additional-jvm-opts"]; found {
+			addOptsSlice, okA := addOpts.([]interface{})
+			overrideAddOptsSlice, okB := overrideAddOpts.([]interface{})
+
+			if !okA || !okB {
+				return fmt.Errorf("additional-jvm-opts must be a list of strings")
+			}
+
+			options["additional-jvm-opts"] = append(addOptsSlice, overrideAddOptsSlice...)
+		} else {
+			// The original options had no additional-jvm-opts, we use our value as is
+			options["additional-jvm-opts"] = overrideAddOpts
+		}
+	}
+
+	for k, v := range overrideOptions {
+		if k == "additional-jvm-opts" || k == "garbage_collector" {
+			continue
+		}
+		options[k] = v
 	}
 
 	targetOptions := make([]string, 0, len(currentOptions)+len(options))
@@ -317,10 +394,6 @@ func createServerJVMOptions(options map[string]any, filename, sourceDir, targetD
 				targetOptions = append(targetOptions, outputVal.Output(fmt.Sprintf("%v", v)))
 			}
 		}
-	}
-
-	if options == nil {
-		options = make(map[string]any)
 	}
 
 	// If filename matches jvm.*-server.options and has garbage_collector setting
@@ -374,6 +447,11 @@ curOptions:
 			}
 		}
 		targetOptions = append(targetOptions, v)
+	}
+
+	if len(targetOptions) == 0 {
+		// Nothing to write; skip creating an empty file
+		return nil
 	}
 
 	targetFileT := filepath.Join(targetDir, filename)
@@ -523,18 +601,52 @@ func readJvmServerOptions(path string) ([]string, error) {
 	return options, nil
 }
 
-// cassandra.yaml related functions
+// readPodOverrides attempts to read per-pod overrides from inputDir/<POD_NAME>.yaml or .json.
+// Returns nil if no overrides are present.
+func readPodOverrides(inputDir, podSpecificDir string, nodeInfo *NodeInfo) (*ConfigInput, error) {
+	override := &ConfigInput{}
+	if nodeInfo.Name == "" {
+		return override, nil
+	}
 
-func createCassandraYaml(configInput *ConfigInput, nodeInfo *NodeInfo, sourceDir, targetDir string) error {
+	podConfigPrefix := filepath.Join(inputDir, podSpecificDir, nodeInfo.Name)
+
+	// While YAML is not the format that CONFIG_FILE_DATA supports from cass-operator,
+	// we prefer this way of formatting if users are manually creating the overrides instead of the operator.
+	// We still prefer the same format as CONFIG_FILE_DATA as the primary one
+	yamlPath := podConfigPrefix + ".yaml"
+	jsonPath := podConfigPrefix + ".json"
+
+	if _, err := os.Stat(jsonPath); err == nil {
+		log.Infof("Found pod-specific JSON overrides at %s", jsonPath)
+		data, err := os.ReadFile(jsonPath)
+		if err != nil {
+			return nil, err
+		}
+		return parseConfigInputFromData(string(data))
+	} else if _, err := os.Stat(yamlPath); err == nil {
+		log.Infof("Found pod-specific YAML overrides at %s", yamlPath)
+		data, err := os.ReadFile(yamlPath)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := yaml.Unmarshal(data, override); err != nil {
+			return nil, err
+		}
+	}
+
+	return override, nil
+}
+
+func createCassandraYaml(configInput *ConfigInput, nodeInfo *NodeInfo, sourceDir, targetDir string, finalOverrides map[string]interface{}) error {
 	targetConfigFileName := oldCassandraConfigName
 	// Verify if we should use cassandra_latest.yaml (5.0 and newer) or cassandra.yaml (4.1 and older)
 	if _, err := os.Stat(filepath.Join(sourceDir, latestCassandraConfigName)); err == nil {
 		targetConfigFileName = latestCassandraConfigName
 	}
 
-	// Read the base file
 	yamlPath := filepath.Join(sourceDir, targetConfigFileName)
-
 	yamlFile, err := os.ReadFile(yamlPath)
 	if err != nil {
 		return err
@@ -547,7 +659,7 @@ func createCassandraYaml(configInput *ConfigInput, nodeInfo *NodeInfo, sourceDir
 		return err
 	}
 
-	// Merge with the ConfigInput's cassadraYaml changes - configInput.CassYaml changes have to take priority
+	// Merge with the ConfigInput's cassandraYaml changes - configInput.CassYaml changes have to take priority
 	merged, err := goalesce.DeepMerge(cassandraYaml, configInput.CassYaml)
 	if err != nil {
 		return err
@@ -571,6 +683,22 @@ func createCassandraYaml(configInput *ConfigInput, nodeInfo *NodeInfo, sourceDir
 	// Take the NodeInfo information and add those modifications to the merge output (a priority)
 	// Take the mandatory changes we require and merge them (a priority again)
 	merged = k8ssandraOverrides(merged, configInput, nodeInfo)
+
+	// Apply per-pod final overrides last (highest priority) - these could break the configuration
+	if len(finalOverrides) > 0 {
+		merged2, err := goalesce.DeepMerge(merged, finalOverrides)
+		if err != nil {
+			return err
+		}
+		// Same goalesce "hotfix"
+		for k, v := range finalOverrides {
+			rv := reflect.ValueOf(v)
+			if rv.Kind() == reflect.Bool {
+				merged2[k] = rv.Bool()
+			}
+		}
+		merged = merged2
+	}
 
 	// Write to the targetDir the new modified file
 	targetFile := filepath.Join(targetDir, "cassandra.yaml")
@@ -627,7 +755,7 @@ func writeYaml(doc map[string]any, targetFile string) error {
 
 func copyFiles(sourceDir, targetDir string) error {
 	// Copy the files we're not modifying
-	files := []string{"jvm-clients.options", "jvm11-clients.options", "jvm17-clients.options", "logback.xml", "logback-tools.xml", "jvm-dependent.sh", "jvm.options"}
+	files := []string{"jvm-clients.options", "jvm11-clients.options", "jvm17-clients.options", "logback.xml", "logback-tools.xml", "jvm-dependent.sh", "jvm.options", "cassandra-jaas.config"}
 
 	for _, f := range files {
 		sourceFile := filepath.Join(sourceDir, f)

--- a/pkg/config/builder_test.go
+++ b/pkg/config/builder_test.go
@@ -198,7 +198,7 @@ var removeAllocateTokens = `
 
 func TestBuilderDefaults(t *testing.T) {
 	require := require.New(t)
-	builder := NewBuilder("", "")
+	builder := NewBuilder("", "", "")
 	require.Equal(defaultInputDir, builder.configInputDir)
 	require.Equal(defaultOutputDir, builder.configOutputDir)
 }
@@ -267,7 +267,7 @@ func TestBuild(t *testing.T) {
 	inputDir := filepath.Join(envtest.RootDir(), "testfiles")
 	tempDir := t.TempDir()
 
-	b := NewBuilder(inputDir, tempDir)
+	b := NewBuilder(inputDir, tempDir, "")
 	require.NoError(b.Build(t.Context()))
 
 	// Verify that all target files are there..
@@ -305,7 +305,7 @@ func TestCassandraYamlWriting(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(nodeInfo)
 
-	require.NoError(createCassandraYaml(configInput, nodeInfo, cassYamlDir, tempDir))
+	require.NoError(createCassandraYaml(configInput, nodeInfo, cassYamlDir, tempDir, nil))
 
 	yamlOrigPath := filepath.Join(cassYamlDir, "cassandra_latest.yaml")
 	yamlPath := filepath.Join(tempDir, "cassandra.yaml")
@@ -378,8 +378,8 @@ func TestCassandraBaseConfigFilePick(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(nodeInfo)
 
-	require.NoError(createCassandraYaml(configInput, nodeInfo, inputDirOld, outputDirOld))
-	require.NoError(createCassandraYaml(configInput, nodeInfo, inputDirNew, outputDirNew))
+	require.NoError(createCassandraYaml(configInput, nodeInfo, inputDirOld, outputDirOld, nil))
+	require.NoError(createCassandraYaml(configInput, nodeInfo, inputDirNew, outputDirNew, nil))
 
 	// Verify only cassandra.yaml is created to destination
 	entriesOld, err := os.ReadDir(outputDirOld)
@@ -428,7 +428,7 @@ func TestCassandraYamlSubPath(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(nodeInfo)
 
-	require.NoError(createCassandraYaml(configInput, nodeInfo, cassYamlDir, tempDir))
+	require.NoError(createCassandraYaml(configInput, nodeInfo, cassYamlDir, tempDir, nil))
 
 	yamlPath := filepath.Join(tempDir, "cassandra.yaml")
 
@@ -460,7 +460,7 @@ func TestBooleanOverride(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(nodeInfo)
 
-	require.NoError(createCassandraYaml(configInput, nodeInfo, cassYamlDir, tempDir))
+	require.NoError(createCassandraYaml(configInput, nodeInfo, cassYamlDir, tempDir, nil))
 
 	yamlPath := filepath.Join(tempDir, "cassandra.yaml")
 
@@ -494,7 +494,7 @@ func TestNilOverride(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(nodeInfo)
 
-	require.NoError(createCassandraYaml(configInput, nodeInfo, cassYamlDir, tempDir))
+	require.NoError(createCassandraYaml(configInput, nodeInfo, cassYamlDir, tempDir, nil))
 
 	yamlPath := filepath.Join(tempDir, "cassandra.yaml")
 
@@ -544,7 +544,7 @@ func TestServerOptionsOutput(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(configInput)
 
-	require.NoError(createJVMOptions(configInput, optionsDir, tempDir))
+	require.NoError(createJVMOptions(configInput, optionsDir, tempDir, &ConfigInput{}))
 
 	inputFile := filepath.Join(tempDir, "jvm-server.options")
 	inputFile11 := filepath.Join(tempDir, "jvm11-server.options")
@@ -581,7 +581,7 @@ func TestServerOptionsOutput(t *testing.T) {
 	// Test empty also and check we get the default G1 settings
 	ci := &ConfigInput{}
 	tempDir2 := t.TempDir()
-	require.NoError(createJVMOptions(ci, optionsDir, tempDir2))
+	require.NoError(createJVMOptions(ci, optionsDir, tempDir2, &ConfigInput{}))
 
 	inputFile11 = filepath.Join(tempDir2, "jvm11-server.options")
 
@@ -600,7 +600,7 @@ func TestServerOptionsOutput(t *testing.T) {
 	}
 
 	tempDir3 := t.TempDir()
-	require.NoError(createJVMOptions(ci, optionsDir, tempDir3))
+	require.NoError(createJVMOptions(ci, optionsDir, tempDir3, &ConfigInput{}))
 
 	inputFile11 = filepath.Join(tempDir3, "jvm11-server.options")
 
@@ -640,7 +640,7 @@ func TestJVM17GarbageCollectorOptions(t *testing.T) {
 		},
 	}
 
-	require.NoError(createJVMOptions(ciG1, optionsDir, tempDirG1))
+	require.NoError(createJVMOptions(ciG1, optionsDir, tempDirG1, &ConfigInput{}))
 
 	jvm17FileG1 := filepath.Join(tempDirG1, "jvm17-server.options")
 	optionsG1, err := readJvmServerOptions(jvm17FileG1)
@@ -665,7 +665,7 @@ func TestJVM17GarbageCollectorOptions(t *testing.T) {
 		},
 	}
 
-	require.NoError(createJVMOptions(ciZ, optionsDir, tempDirZ))
+	require.NoError(createJVMOptions(ciZ, optionsDir, tempDirZ, &ConfigInput{}))
 
 	jvm17FileZ := filepath.Join(tempDirZ, "jvm17-server.options")
 	optionsZ, err := readJvmServerOptions(jvm17FileZ)
@@ -690,7 +690,7 @@ func TestJVM17GarbageCollectorOptions(t *testing.T) {
 		},
 	}
 
-	require.NoError(createJVMOptions(ciS, optionsDir, tempDirS))
+	require.NoError(createJVMOptions(ciS, optionsDir, tempDirS, &ConfigInput{}))
 
 	jvm17FileS := filepath.Join(tempDirS, "jvm17-server.options")
 	optionsS, err := readJvmServerOptions(jvm17FileS)
@@ -741,7 +741,7 @@ func TestReadOptionsWithNumeric(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(configInput)
 
-	require.NoError(createJVMOptions(configInput, optionsDir, tempDir))
+	require.NoError(createJVMOptions(configInput, optionsDir, tempDir, &ConfigInput{}))
 
 	lines, err := readFileToLines(tempDir, "jvm-server.options")
 	require.NoError(err)
@@ -765,7 +765,7 @@ func TestCass50GCOverrides(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(nodeInfo)
 
-	require.NoError(createJVMOptions(configInput, cassYamlDir, tempDir))
+	require.NoError(createJVMOptions(configInput, cassYamlDir, tempDir, &ConfigInput{}))
 
 	jvm17OptionsFile := filepath.Join(tempDir, "jvm17-server.options")
 	options, err := readJvmServerOptions(jvm17OptionsFile)
@@ -792,7 +792,7 @@ func TestCass50GCOverridesAdditionalOpts(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(nodeInfo)
 
-	require.NoError(createJVMOptions(configInput, cassYamlDir, tempDir))
+	require.NoError(createJVMOptions(configInput, cassYamlDir, tempDir, &ConfigInput{}))
 
 	jvm17OptionsFile := filepath.Join(tempDir, "jvm17-server.options")
 	options, err := readJvmServerOptions(jvm17OptionsFile)
@@ -841,4 +841,105 @@ func TestCopyFiles(t *testing.T) {
 	// We should have tempDir/jvm11-clients.options
 	_, err := os.Stat(filepath.Join(tempDir, "jvm11-clients.options"))
 	require.NoError(err)
+}
+
+// Helper to copy all files from a directory (non-recursive) for tests
+func copyAllFiles(t *testing.T, srcDir, dstDir string) {
+	t.Helper()
+	entries, err := os.ReadDir(srcDir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		if e.IsDir() {
+			// Only copy top-level files used by builder; subdirs are not required here
+			continue
+		}
+		require.NoError(t, copyFile(filepath.Join(srcDir, e.Name()), filepath.Join(dstDir, e.Name())))
+	}
+}
+
+func TestPerPodOverridesAppliedAfterK8ssandraOverrides(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	// Prepare input dir with base config files plus per-pod override
+	baseDir := filepath.Join(envtest.RootDir(), "testfiles")
+	inputDir := t.TempDir()
+	copyAllFiles(t, baseDir, inputDir)
+
+	// Create per-pod override that sets IPs explicitly
+	podName := "pod-a"
+	override := `cassandra-yaml:
+  listen_address: "1.2.3.4"
+  rpc_address: "1.2.3.5"
+  broadcast_rpc_address: "1.2.3.6"
+`
+	require.NoError(os.MkdirAll(filepath.Join(inputDir, defaultPodSpecificDir), 0755))
+	require.NoError(os.WriteFile(filepath.Join(inputDir, defaultPodSpecificDir, podName+".yaml"), []byte(override), 0600))
+
+	// Standard inputs
+	t.Setenv("CONFIG_FILE_DATA", existingConfig)
+	t.Setenv("POD_NAME", podName)
+	t.Setenv("POD_IP", "172.27.0.1")
+	t.Setenv("RACK_NAME", "r1")
+
+	outputDir := t.TempDir()
+	b := NewBuilder(inputDir, outputDir, "")
+	require.NoError(b.Build(t.Context()))
+
+	// Load the resulting cassandra.yaml and verify per-pod overrides won
+	yamlPath := filepath.Join(outputDir, "cassandra.yaml")
+	contents, err := os.ReadFile(yamlPath)
+	require.NoError(err)
+
+	out := make(map[string]interface{})
+	require.NoError(yaml.Unmarshal(contents, out))
+
+	assert.Equal("1.2.3.4", out["listen_address"])
+	assert.Equal("1.2.3.5", out["rpc_address"])
+	// broadcast_rpc_address may be string or net.IP marshaled; ensure string match when marshaled
+	switch v := out["broadcast_rpc_address"].(type) {
+	case string:
+		assert.Equal("1.2.3.6", v)
+	default:
+		// If not a plain string, marshal back to YAML string and compare contains
+		b, _ := yaml.Marshal(map[string]any{"broadcast_rpc_address": v})
+		assert.Contains(string(b), "1.2.3.6")
+	}
+}
+
+func TestPerPodOverridesMergeJvmOptions(t *testing.T) {
+	require := require.New(t)
+
+	baseDir := filepath.Join(envtest.RootDir(), "testfiles")
+	inputDir := t.TempDir()
+	copyAllFiles(t, baseDir, inputDir)
+
+	// Additional JVM opt via per-pod override
+	podName := "pod-b"
+	override := `jvm-server-options:
+  additional-jvm-opts:
+  - "-Dcom.example.flag=true"
+`
+	require.NoError(os.MkdirAll(filepath.Join(inputDir, defaultPodSpecificDir), 0755))
+	require.NoError(os.WriteFile(filepath.Join(inputDir, defaultPodSpecificDir, podName+".yaml"), []byte(override), 0600))
+
+	// Standard inputs
+	t.Setenv("CONFIG_FILE_DATA", existingConfig)
+	t.Setenv("POD_NAME", podName)
+
+	outputDir := t.TempDir()
+	b := NewBuilder(inputDir, outputDir, "")
+	require.NoError(b.Build(t.Context()))
+
+	lines, err := readFileToLines(outputDir, "jvm-server.options")
+	require.NoError(err)
+	// Ensure the new flag is present
+	found := false
+	for _, l := range lines {
+		if l == "-Dcom.example.flag=true" {
+			found = true
+			break
+		}
+	}
+	require.True(found, "expected additional per-pod JVM option to be present")
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -27,30 +27,31 @@ import "net"
 // From cass-operator JSON input
 
 type ConfigInput struct {
-	ClusterInfo     ClusterInfo         `json:"cluster-info"`
-	DatacenterInfo  DatacenterInfo      `json:"datacenter-info"`
-	CassYaml        map[string]any      `json:"cassandra-yaml,omitempty"`
-	ServerOptions   map[string]any      `json:"jvm-server-options,omitempty"`
-	ServerOptions11 map[string]any      `json:"jvm11-server-options,omitempty"`
-	ServerOptions17 map[string]any      `json:"jvm17-server-options,omitempty"`
-	CassandraEnv    CassandraEnvOptions `json:"cassandra-env-sh"`
+	ClusterInfo     ClusterInfo            `json:"cluster-info" yaml:"cluster-info"`
+	DatacenterInfo  DatacenterInfo         `json:"datacenter-info" yaml:"datacenter-info"`
+	CassYaml        map[string]interface{} `json:"cassandra-yaml,omitempty" yaml:"cassandra-yaml,omitempty"`
+	ServerOptions   map[string]interface{} `json:"jvm-server-options,omitempty" yaml:"jvm-server-options,omitempty"`
+	ServerOptions11 map[string]interface{} `json:"jvm11-server-options,omitempty" yaml:"jvm11-server-options,omitempty"`
+	ServerOptions17 map[string]interface{} `json:"jvm17-server-options,omitempty" yaml:"jvm17-server-options,omitempty"`
+	ServerOptions21 map[string]interface{} `json:"jvm21-server-options,omitempty" yaml:"jvm21-server-options,omitempty"`
+	CassandraEnv    CassandraEnvOptions    `json:"cassandra-env-sh,omitempty" yaml:"cassandra-env-sh,omitempty"`
 
 	// At some point, parse the remaining unknown keys when we decide what to do with them..
 }
 
 type CassandraEnvOptions struct {
-	MallocArenaMax int      `json:"malloc-arena-max,omitempty"`
-	HeapDumpDir    string   `json:"heap-dump-dir,omitempty"`
-	AdditionalOpts []string `json:"additional-jvm-opts,omitempty"`
+	MallocArenaMax int      `json:"malloc-arena-max,omitempty" yaml:"malloc-arena-max,omitempty"`
+	HeapDumpDir    string   `json:"heap-dump-dir,omitempty" yaml:"heap-dump-dir,omitempty"`
+	AdditionalOpts []string `json:"additional-jvm-opts,omitempty" yaml:"additional-jvm-opts,omitempty"`
 }
 
 type ClusterInfo struct {
-	Name  string `json:"name"`
-	Seeds string `json:"seeds"` // comma separated list of seeds
+	Name  string `json:"name" yaml:"name"`
+	Seeds string `json:"seeds" yaml:"seeds"` // comma separated list of seeds
 }
 
 type DatacenterInfo struct {
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// These are ignored for now
 	// "graph-enabled": graphEnabled,

--- a/pkg/helmutil/crds_test.go
+++ b/pkg/helmutil/crds_test.go
@@ -1,7 +1,6 @@
 package helmutil_test
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -36,7 +35,7 @@ func TestUpgradingCRDs(t *testing.T) {
 		u, err := helmutil.NewUpgrader(kubeClient, helmutil.K8ssandraRepoName, helmutil.StableK8ssandraRepoURL, chartName, []string{})
 		require.NoError(err)
 
-		crds, err := u.Upgrade(context.TODO(), "0.42.0")
+		crds, err := u.Upgrade(t.Context(), "0.42.0")
 		require.NoError(err)
 
 		testOptions := envtest.CRDInstallOptions{
@@ -57,7 +56,7 @@ func TestUpgradingCRDs(t *testing.T) {
 		require.NotEmpty(objs)
 		require.NotEmpty(cassDCCRD.GetName())
 		require.NoError(envtest.WaitForCRDs(env.RestConfig(), objs, testOptions))
-		require.NoError(kubeClient.Get(context.TODO(), client.ObjectKey{Name: cassDCCRD.GetName()}, cassDCCRD))
+		require.NoError(kubeClient.Get(t.Context(), client.ObjectKey{Name: cassDCCRD.GetName()}, cassDCCRD))
 		ver := cassDCCRD.GetResourceVersion()
 
 		descRunsAsCassandra := cassDCCRD.Spec.Versions[0].DeepCopy().Schema.OpenAPIV3Schema.Properties["spec"].Properties["dockerImageRunsAsCassandra"].Description
@@ -65,14 +64,14 @@ func TestUpgradingCRDs(t *testing.T) {
 
 		// Upgrading to 0.46.1
 		require.NoError(cleanCache("k8ssandra", chartName))
-		_, err = u.Upgrade(context.TODO(), "0.46.1")
+		_, err = u.Upgrade(t.Context(), "0.46.1")
 		require.NoError(err)
 
 		require.NoError(envtest.WaitForCRDs(env.RestConfig(), objs, testOptions))
-		require.NoError(kubeClient.Get(context.TODO(), client.ObjectKey{Name: cassDCCRD.GetName()}, cassDCCRD))
+		require.NoError(kubeClient.Get(t.Context(), client.ObjectKey{Name: cassDCCRD.GetName()}, cassDCCRD))
 
 		require.Eventually(func() bool {
-			require.NoError(kubeClient.Get(context.TODO(), client.ObjectKey{Name: cassDCCRD.GetName()}, cassDCCRD))
+			require.NoError(kubeClient.Get(t.Context(), client.ObjectKey{Name: cassDCCRD.GetName()}, cassDCCRD))
 			newver := cassDCCRD.GetResourceVersion()
 			return newver != ver
 		}, time.Minute*1, time.Millisecond*100)
@@ -122,7 +121,7 @@ func TestUpgradingStoredVersions(t *testing.T) {
 	u, err := helmutil.NewUpgrader(kubeClient, helmutil.K8ssandraRepoName, helmutil.StableK8ssandraRepoURL, chartName, []string{})
 	require.NoError(err)
 
-	crds, err := u.Upgrade(context.TODO(), "0.1.0")
+	crds, err := u.Upgrade(t.Context(), "0.1.0")
 	require.NoError(err)
 
 	targetCrd := &apiextensions.CustomResourceDefinition{}
@@ -136,7 +135,7 @@ func TestUpgradingStoredVersions(t *testing.T) {
 	require.NotEmpty(objs)
 	require.NotEmpty(targetCrd.GetName())
 	require.NoError(envtest.WaitForCRDs(env.RestConfig(), objs, testOptions))
-	require.NoError(kubeClient.Get(context.TODO(), client.ObjectKey{Name: targetCrd.GetName()}, targetCrd))
+	require.NoError(kubeClient.Get(t.Context(), client.ObjectKey{Name: targetCrd.GetName()}, targetCrd))
 
 	require.Equal([]string{"v1alpha1"}, targetCrd.Status.StoredVersions)
 
@@ -148,7 +147,7 @@ func TestUpgradingStoredVersions(t *testing.T) {
 	crdSrc = filepath.Join("..", "..", "testfiles", "crd-upgrader", "multiversion-clientconfig-mockup-both.yaml")
 	require.NoError(copyFile(crdSrc, filepath.Join(crdDir, "clientconfig.yaml")))
 
-	crds, err = u.Upgrade(context.TODO(), "0.2.0")
+	crds, err = u.Upgrade(t.Context(), "0.2.0")
 	require.NoError(err)
 	for _, crd := range crds {
 		err = runtime.DefaultUnstructuredConverter.FromUnstructured(crd.UnstructuredContent(), targetCrd)
@@ -157,7 +156,7 @@ func TestUpgradingStoredVersions(t *testing.T) {
 	}
 	require.NotEmpty(objs)
 	require.NoError(envtest.WaitForCRDs(env.RestConfig(), objs, testOptions))
-	require.NoError(kubeClient.Get(context.TODO(), client.ObjectKey{Name: targetCrd.GetName()}, targetCrd))
+	require.NoError(kubeClient.Get(t.Context(), client.ObjectKey{Name: targetCrd.GetName()}, targetCrd))
 	require.Equal([]string{"v1alpha1", "v1beta1"}, targetCrd.Status.StoredVersions)
 
 	// Upgrade to 0.3.0
@@ -168,7 +167,7 @@ func TestUpgradingStoredVersions(t *testing.T) {
 	crdSrc = filepath.Join("..", "..", "testfiles", "crd-upgrader", "multiversion-clientconfig-mockup-v1beta1.yaml")
 	require.NoError(copyFile(crdSrc, filepath.Join(crdDir, "clientconfig.yaml")))
 
-	crds, err = u.Upgrade(context.TODO(), "0.3.0")
+	crds, err = u.Upgrade(t.Context(), "0.3.0")
 	require.NoError(err)
 	for _, crd := range crds {
 		err = runtime.DefaultUnstructuredConverter.FromUnstructured(crd.UnstructuredContent(), targetCrd)
@@ -177,13 +176,13 @@ func TestUpgradingStoredVersions(t *testing.T) {
 	}
 	require.NotEmpty(objs)
 	require.NoError(envtest.WaitForCRDs(env.RestConfig(), objs, testOptions))
-	require.NoError(kubeClient.Get(context.TODO(), client.ObjectKey{Name: targetCrd.GetName()}, targetCrd))
+	require.NoError(kubeClient.Get(t.Context(), client.ObjectKey{Name: targetCrd.GetName()}, targetCrd))
 	require.Equal([]string{"v1beta1"}, targetCrd.Status.StoredVersions)
 
 	// Sanity check, install 0.2.0 and only update to 0.3.0 (there should be no storedVersion of v1alpha1)
-	require.NoError(kubeClient.Delete(context.TODO(), targetCrd))
+	require.NoError(kubeClient.Delete(t.Context(), targetCrd))
 	require.Eventually(func() bool {
-		err = kubeClient.Get(context.TODO(), client.ObjectKey{Name: targetCrd.GetName()}, targetCrd)
+		err = kubeClient.Get(t.Context(), client.ObjectKey{Name: targetCrd.GetName()}, targetCrd)
 		return err != nil && client.IgnoreNotFound(err) == nil
 	}, time.Second*5, time.Millisecond*100)
 
@@ -195,7 +194,7 @@ func TestUpgradingStoredVersions(t *testing.T) {
 	crdSrc = filepath.Join("..", "..", "testfiles", "crd-upgrader", "multiversion-clientconfig-mockup-both.yaml")
 	require.NoError(copyFile(crdSrc, filepath.Join(crdDir, "clientconfig.yaml")))
 
-	crds, err = u.Upgrade(context.TODO(), "0.2.0")
+	crds, err = u.Upgrade(t.Context(), "0.2.0")
 	require.NoError(err)
 	for _, crd := range crds {
 		err = runtime.DefaultUnstructuredConverter.FromUnstructured(crd.UnstructuredContent(), targetCrd)
@@ -204,7 +203,7 @@ func TestUpgradingStoredVersions(t *testing.T) {
 	}
 	require.NotEmpty(objs)
 	require.NoError(envtest.WaitForCRDs(env.RestConfig(), objs, testOptions))
-	require.NoError(kubeClient.Get(context.TODO(), client.ObjectKey{Name: targetCrd.GetName()}, targetCrd))
+	require.NoError(kubeClient.Get(t.Context(), client.ObjectKey{Name: targetCrd.GetName()}, targetCrd))
 	require.Equal([]string{"v1beta1"}, targetCrd.Status.StoredVersions)
 
 	// Upgrade to 0.3.0
@@ -215,7 +214,7 @@ func TestUpgradingStoredVersions(t *testing.T) {
 	crdSrc = filepath.Join("..", "..", "testfiles", "crd-upgrader", "multiversion-clientconfig-mockup-v1beta1.yaml")
 	require.NoError(copyFile(crdSrc, filepath.Join(crdDir, "clientconfig.yaml")))
 
-	crds, err = u.Upgrade(context.TODO(), "0.3.0")
+	crds, err = u.Upgrade(t.Context(), "0.3.0")
 	require.NoError(err)
 	for _, crd := range crds {
 		err = runtime.DefaultUnstructuredConverter.FromUnstructured(crd.UnstructuredContent(), targetCrd)
@@ -224,7 +223,7 @@ func TestUpgradingStoredVersions(t *testing.T) {
 	}
 	require.NotEmpty(objs)
 	require.NoError(envtest.WaitForCRDs(env.RestConfig(), objs, testOptions))
-	require.NoError(kubeClient.Get(context.TODO(), client.ObjectKey{Name: targetCrd.GetName()}, targetCrd))
+	require.NoError(kubeClient.Get(t.Context(), client.ObjectKey{Name: targetCrd.GetName()}, targetCrd))
 	require.Equal([]string{"v1beta1"}, targetCrd.Status.StoredVersions)
 }
 

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -44,14 +44,14 @@ func GetClientInNamespace(restConfig *rest.Config, namespace string) (Namespaced
 	// return c, nil
 }
 
-func CreateNamespaceIfNotExists(client client.Client, namespace string) error {
+func CreateNamespaceIfNotExists(ctx context.Context, client client.Client, namespace string) error {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: namespace,
 		},
 	}
 
-	if err := client.Create(context.TODO(), ns); err != nil && !errors.IsAlreadyExists(err) {
+	if err := client.Create(ctx, ns); err != nil && !errors.IsAlreadyExists(err) {
 		return err
 	}
 

--- a/pkg/scheduler/fit_test.go
+++ b/pkg/scheduler/fit_test.go
@@ -1,7 +1,6 @@
 package scheduler
 
 import (
-	"context"
 	"testing"
 
 	api "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
@@ -16,7 +15,7 @@ import (
 
 func TestSmokeResources(t *testing.T) {
 	require := require.New(t)
-	ctx := context.TODO()
+	ctx := t.Context()
 	cli := createClient()
 	require.NoError(cli.Create(ctx, makeNode("node1")))
 
@@ -35,7 +34,7 @@ func TestSmokeResources(t *testing.T) {
 
 func TestSmokeTolerations(t *testing.T) {
 	require := require.New(t)
-	ctx := context.TODO()
+	ctx := t.Context()
 	cli := createClient()
 	n := makeNode("node1")
 	n.Spec.Taints = []corev1.Taint{
@@ -68,7 +67,7 @@ func TestSmokeTolerations(t *testing.T) {
 
 func TestSmokeNodeAffinity(t *testing.T) {
 	require := require.New(t)
-	ctx := context.TODO()
+	ctx := t.Context()
 	cli := createClient()
 	n := makeNode("node1")
 	require.NoError(cli.Create(ctx, n))
@@ -106,7 +105,7 @@ func TestSmokeNodeAffinity(t *testing.T) {
 
 func TestSmokeInternodePodAffinity(t *testing.T) {
 	require := require.New(t)
-	ctx := context.TODO()
+	ctx := t.Context()
 	cli := createClient()
 	require.NoError(cli.Create(ctx, makeNode("node1")))
 	pod := makePod("pod1", makeResources(100, 100, 1))


### PR DESCRIPTION
This allows to use perPodConfiguration with Kubernetes 1.33 (subPathExpr) without the use of webhook.

Also removes the use of context.TODO() and replaces it with t.Context()