### PR TITLE
Fix Dockerfile to include TARGETOS and TARGETARCH in the ubi-builder stage

### DIFF
--- a/cmd/kubectl-k8ssandra/Dockerfile
+++ b/cmd/kubectl-k8ssandra/Dockerfile
@@ -25,6 +25,8 @@ FROM redhat/ubi9-minimal:latest AS ubi-builder
 
 ARG YQ_VERSION
 ARG KUBE_VERSION
+ARG TARGETOS
+ARG TARGETARCH
 
 # Install kubectl
 RUN cat <<EOF | tee /etc/yum.repos.d/kubernetes.repo


### PR DESCRIPTION
Fixes #113 